### PR TITLE
Update the referenced component version.

### DIFF
--- a/Hangfire.DMStorage.NetCore/Hangfire.DMStorage.NetCore.csproj
+++ b/Hangfire.DMStorage.NetCore/Hangfire.DMStorage.NetCore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.25" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.26" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>

--- a/src/Hangfire.DMStorage/Hangfire.DMStorage.csproj
+++ b/src/Hangfire.DMStorage/Hangfire.DMStorage.csproj
@@ -50,7 +50,7 @@ Hangfire 达梦数据库存储。</Description>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="DM.DmProvider" Version="8.3.1.28188" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.25" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.26" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Because Hangfire.Core 1.7.25 has an officially reported security issue, the version referenced in this project has been updated to 1.7.26.